### PR TITLE
Milestone 2: ファイルシステム対応

### DIFF
--- a/lib/acp_client.rb
+++ b/lib/acp_client.rb
@@ -9,7 +9,7 @@ require_relative "acp_client/response_handler"
 require_relative "acp_client/client"
 
 module AcpClient
-  def self.new
-    Client.new
+  def self.new(**kwargs)
+    Client.new(**kwargs)
   end
 end

--- a/lib/acp_client/client.rb
+++ b/lib/acp_client/client.rb
@@ -4,10 +4,12 @@ module AcpClient
   class Client
     attr_reader :json_rpc, :process_manager, :response_handler
 
-    def initialize
+    def initialize(fs_read_text_file: nil, fs_write_text_file: nil)
       @json_rpc = JsonRpc.new
       @process_manager = ProcessManager.new
       @response_handler = nil
+      @fs_read_text_file = fs_read_text_file
+      @fs_write_text_file = fs_write_text_file
     end
 
     def interactive_session!
@@ -24,6 +26,9 @@ module AcpClient
         process_manager: @process_manager,
         json_rpc: @json_rpc
       )
+
+      @response_handler.on_fs_read_text_file(&@fs_read_text_file) if @fs_read_text_file
+      @response_handler.on_fs_write_text_file(&@fs_write_text_file) if @fs_write_text_file
 
       @response_handler.on_text_chunk do |text|
         print text

--- a/lib/acp_client/response_handler.rb
+++ b/lib/acp_client/response_handler.rb
@@ -29,10 +29,20 @@ module AcpClient
       @reader_thread = nil
       @stderr_thread = nil
       @on_text_chunk = nil
+      @on_fs_read_text_file = nil
+      @on_fs_write_text_file = nil
     end
 
     def on_text_chunk(&block)
       @on_text_chunk = block
+    end
+
+    def on_fs_read_text_file(&block)
+      @on_fs_read_text_file = block
+    end
+
+    def on_fs_write_text_file(&block)
+      @on_fs_write_text_file = block
     end
 
     def start_threads
@@ -106,9 +116,91 @@ module AcpClient
     def handle_message(msg)
       if msg["id"].nil? && msg["method"]
         handle_notification(msg)
+      elsif msg["method"] && msg.key?("id") && !msg.key?("result") && !msg.key?("error")
+        handle_incoming_request(msg)
       else
         handle_response(msg)
       end
+    end
+
+    def handle_incoming_request(msg)
+      id = msg["id"]
+      method_name = msg["method"]
+      params = msg["params"] || {}
+
+      case method_name
+      when "fs/read_text_file"
+        handle_fs_read_text_file(id, params)
+      when "fs/write_text_file"
+        handle_fs_write_text_file(id, params)
+      else
+        send_error_response(id, -32601, "Method not found: #{method_name}")
+      end
+    end
+
+    def handle_fs_read_text_file(id, params)
+      path = params["path"]
+      line = params["line"]
+      limit = params["limit"]
+
+      content = if @on_fs_read_text_file
+        @on_fs_read_text_file.call(path, line, limit)
+      else
+        default_fs_read_text_file(path, line, limit)
+      end
+
+      send_response(id, {content: content})
+    rescue Errno::ENOENT => e
+      send_error_response(id, -32000, "File not found: #{e.message}")
+    rescue => e
+      send_error_response(id, -32603, "Internal error: #{e.message}")
+    end
+
+    def handle_fs_write_text_file(id, params)
+      path = params["path"]
+      content = params["content"] || ""
+
+      if @on_fs_write_text_file
+        @on_fs_write_text_file.call(path, content)
+      else
+        default_fs_write_text_file(path, content)
+      end
+
+      send_response(id, nil)
+    rescue => e
+      send_error_response(id, -32603, "Internal error: #{e.message}")
+    end
+
+    def default_fs_read_text_file(path, line, limit)
+      full_content = File.read(path)
+      return full_content if line.nil? && limit.nil?
+
+      lines = full_content.lines
+      start_idx = line ? [(line - 1), 0].max : 0
+      count = limit ? [limit, lines.size - start_idx].min : (lines.size - start_idx)
+      lines[start_idx, count]&.join || ""
+    end
+
+    def default_fs_write_text_file(path, content)
+      File.write(path, content)
+    end
+
+    def send_response(id, result)
+      response = {
+        jsonrpc: "2.0",
+        id: id,
+        result: result
+      }
+      @process_manager.send_message(response)
+    end
+
+    def send_error_response(id, code, message)
+      response = {
+        jsonrpc: "2.0",
+        id: id,
+        error: {code: code, message: message}
+      }
+      @process_manager.send_message(response)
     end
 
     def handle_notification(msg)

--- a/test/test_fs_handlers.rb
+++ b/test/test_fs_handlers.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tempfile"
+
+class TestFsHandlers < Minitest::Test
+  def setup
+    @pm = MockProcessManager.new
+    @pm.start
+    @rpc = AcpClient::JsonRpc.new
+    @handler = AcpClient::ResponseHandler.new(process_manager: @pm, json_rpc: @rpc)
+  end
+
+  def teardown
+    @pm.close
+  end
+
+  def test_fs_read_text_file_default
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    tmp = Tempfile.new("acp_test")
+    tmp.write("line1\nline2\nline3\nline4\nline5")
+    tmp.close
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 10,
+      "method" => "fs/read_text_file",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "path" => tmp.path
+      }
+    }.to_json)
+
+    sleep 0.1
+    assert_operator @pm.messages_sent.size, :>=, 1
+    resp = @pm.messages_sent.find { |m| m[:id] == 10 }
+    assert resp, "Expected response for request id 10"
+    assert_equal "line1\nline2\nline3\nline4\nline5", resp[:result][:content]
+
+    tmp.unlink
+  end
+
+  def test_fs_read_text_file_with_line_and_limit
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    tmp = Tempfile.new("acp_test")
+    tmp.write("line1\nline2\nline3\nline4\nline5")
+    tmp.close
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 11,
+      "method" => "fs/read_text_file",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "path" => tmp.path,
+        "line" => 2,
+        "limit" => 2
+      }
+    }.to_json)
+
+    sleep 0.1
+    resp = @pm.messages_sent.find { |m| m[:id] == 11 }
+    assert resp, "Expected response for request id 11"
+    assert_equal "line2\nline3\n", resp[:result][:content]
+
+    tmp.unlink
+  end
+
+  def test_fs_write_text_file_default
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    tmp = Tempfile.new("acp_test")
+    path = tmp.path
+    tmp.close
+    tmp.unlink
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 12,
+      "method" => "fs/write_text_file",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "path" => path,
+        "content" => "hello world"
+      }
+    }.to_json)
+
+    sleep 0.1
+    resp = @pm.messages_sent.find { |m| m[:id] == 12 }
+    assert resp, "Expected response for request id 12"
+    assert_nil resp[:result]
+    assert_equal "hello world", File.read(path)
+
+    File.unlink(path)
+  end
+
+  def test_fs_read_text_file_custom_handler
+    read_content = nil
+    @handler.on_fs_read_text_file do |path, line, limit|
+      read_content = [path, line, limit]
+      "custom content"
+    end
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 13,
+      "method" => "fs/read_text_file",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "path" => "/tmp/foo",
+        "line" => 5,
+        "limit" => 10
+      }
+    }.to_json)
+
+    sleep 0.1
+    assert_equal ["/tmp/foo", 5, 10], read_content
+    resp = @pm.messages_sent.find { |m| m[:id] == 13 }
+    assert resp, "Expected response for request id 13"
+    assert_equal "custom content", resp[:result][:content]
+  end
+
+  def test_unknown_method_returns_error
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 99,
+      "method" => "unknown/method",
+      "params" => {}
+    }.to_json)
+
+    sleep 0.1
+    resp = @pm.messages_sent.find { |m| m[:id] == 99 }
+    assert resp, "Expected error response for request id 99"
+    assert resp[:error]
+    assert_equal(-32601, resp[:error][:code])
+    assert_includes resp[:error][:message], "Method not found"
+  end
+
+  private
+
+  def init_and_session_flow(pm)
+    pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 0, "result" => {"protocolVersion" => 1, "agentCapabilities" => {}}}.to_json)
+    pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 1, "result" => {"sessionId" => "sess_test123"}}.to_json)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,42 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "acp_client"
 
 require "minitest/autorun"
+
+class MockProcessManager
+  attr_reader :messages_sent, :stdout_lines, :stderr_lines
+
+  def initialize
+    @messages_sent = []
+    @stdout_io = nil
+    @stderr_io = nil
+  end
+
+  def start
+    @stdout_reader, @stdout_writer = IO.pipe
+    @stderr_reader, @stderr_writer = IO.pipe
+    @stdout_lines = []
+    @stderr_lines = []
+  end
+
+  def stdout
+    @stdout_reader
+  end
+
+  def stderr
+    @stderr_reader
+  end
+
+  def send_message(message)
+    @messages_sent << message
+  end
+
+  def inject_stdout_line(json)
+    @stdout_writer.puts(json)
+    @stdout_writer.flush
+  end
+
+  def close
+    @stdout_writer&.close
+    @stderr_writer&.close
+  end
+end

--- a/test/test_response_handler.rb
+++ b/test/test_response_handler.rb
@@ -2,45 +2,6 @@
 
 require "test_helper"
 
-class MockProcessManager
-  attr_reader :messages_sent, :stdout_lines, :stderr_lines
-
-  def initialize
-    @messages_sent = []
-    @stdout_io = nil
-    @stderr_io = nil
-  end
-
-  def start
-    @stdout_reader, @stdout_writer = IO.pipe
-    @stderr_reader, @stderr_writer = IO.pipe
-    @stdout_lines = []
-    @stderr_lines = []
-  end
-
-  def stdout
-    @stdout_reader
-  end
-
-  def stderr
-    @stderr_reader
-  end
-
-  def send_message(message)
-    @messages_sent << message
-  end
-
-  def inject_stdout_line(json)
-    @stdout_writer.puts(json)
-    @stdout_writer.flush
-  end
-
-  def close
-    @stdout_writer&.close
-    @stderr_writer&.close
-  end
-end
-
 class TestResponseHandler < Minitest::Test
   def setup
     @pm = MockProcessManager.new


### PR DESCRIPTION
## 概要
ACP の fs/read_text_file, fs/write_text_file に対応しました。Agent が Client にファイル操作をリクエストできるようになります。

## 変更内容

### 双方向メッセージング
- Agent からのリクエスト（method + id）を `handle_incoming_request` で検出・ルーティング
- 未対応メソッドは JSON-RPC -32601 で応答

### fs/read_text_file
- デフォルト: File.read、line/limit で部分読み込み対応
- カスタム: `on_fs_read_text_file { |path, line, limit| ... }`

### fs/write_text_file
- デフォルト: File.write
- カスタム: `on_fs_write_text_file { |path, content| ... }`

### API
- `AcpClient.new(fs_read_text_file: ->(path, line, limit) { ... }, fs_write_text_file: ->(path, content) { ... })`
- ResponseHandler: `on_fs_read_text_file`, `on_fs_write_text_file` でコールバック設定

## 依存
- Milestone 1 (#TBD) をベースにしています

Made with [Cursor](https://cursor.com)