### PR TITLE
Milestone 3: ターミナル対応

### DIFF
--- a/lib/acp_client.rb
+++ b/lib/acp_client.rb
@@ -5,6 +5,7 @@ require_relative "acp_client/errors"
 require_relative "acp_client/message_buffer"
 require_relative "acp_client/json_rpc"
 require_relative "acp_client/process_manager"
+require_relative "acp_client/terminal_manager"
 require_relative "acp_client/response_handler"
 require_relative "acp_client/client"
 

--- a/lib/acp_client/response_handler.rb
+++ b/lib/acp_client/response_handler.rb
@@ -6,9 +6,10 @@ module AcpClient
   class ResponseHandler
     attr_reader :session_id, :initialized, :agent_capabilities
 
-    def initialize(process_manager:, json_rpc:)
+    def initialize(process_manager:, json_rpc:, terminal_manager: nil)
       @process_manager = process_manager
       @json_rpc = json_rpc
+      @terminal_manager = terminal_manager || TerminalManager.new
 
       @mutex = Mutex.new
       @ready = ConditionVariable.new
@@ -133,6 +134,16 @@ module AcpClient
         handle_fs_read_text_file(id, params)
       when "fs/write_text_file"
         handle_fs_write_text_file(id, params)
+      when "terminal/create"
+        handle_terminal_create(id, params)
+      when "terminal/output"
+        handle_terminal_output(id, params)
+      when "terminal/wait_for_exit"
+        handle_terminal_wait_for_exit(id, params)
+      when "terminal/kill"
+        handle_terminal_kill(id, params)
+      when "terminal/release"
+        handle_terminal_release(id, params)
       else
         send_error_response(id, -32601, "Method not found: #{method_name}")
       end
@@ -183,6 +194,67 @@ module AcpClient
 
     def default_fs_write_text_file(path, content)
       File.write(path, content)
+    end
+
+    def handle_terminal_create(id, params)
+      session_id = params["sessionId"]
+      command = params["command"] || "sh"
+      args = params["args"] || []
+      env = params["env"] || []
+      cwd = params["cwd"]
+      output_byte_limit = params["outputByteLimit"] || 1_048_576
+
+      terminal_id = @terminal_manager.create(
+        session_id: session_id,
+        command: command,
+        args: args,
+        env: env,
+        cwd: cwd,
+        output_byte_limit: output_byte_limit
+      )
+      send_response(id, {terminalId: terminal_id})
+    rescue => e
+      send_error_response(id, -32603, "Internal error: #{e.message}")
+    end
+
+    def handle_terminal_output(id, params)
+      terminal_id = params["terminalId"]
+      result = @terminal_manager.output(terminal_id)
+      send_response(id, result)
+    rescue ProtocolError => e
+      send_error_response(id, -32000, e.message)
+    rescue => e
+      send_error_response(id, -32603, "Internal error: #{e.message}")
+    end
+
+    def handle_terminal_wait_for_exit(id, params)
+      terminal_id = params["terminalId"]
+      result = @terminal_manager.wait_for_exit(terminal_id)
+      send_response(id, result)
+    rescue ProtocolError => e
+      send_error_response(id, -32000, e.message)
+    rescue => e
+      send_error_response(id, -32603, "Internal error: #{e.message}")
+    end
+
+    def handle_terminal_kill(id, params)
+      terminal_id = params["terminalId"]
+      @terminal_manager.kill(terminal_id)
+      send_response(id, nil)
+    rescue ProtocolError => e
+      send_error_response(id, -32000, e.message)
+    rescue => e
+      send_error_response(id, -32603, "Internal error: #{e.message}")
+    end
+
+    def handle_terminal_release(id, params)
+      terminal_id = params["terminalId"]
+      @terminal_manager.release(terminal_id)
+      send_response(id, nil)
+    rescue ProtocolError => e
+      send_error_response(id, -32000, e.message)
+    rescue => e
+      send_error_response(id, -32603, "Internal error: #{e.message}")
     end
 
     def send_response(id, result)

--- a/lib/acp_client/terminal_manager.rb
+++ b/lib/acp_client/terminal_manager.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "open3"
+
+module AcpClient
+  class TerminalManager
+    def initialize
+      @mutex = Mutex.new
+      @terminals = {}
+      @next_id = 0
+    end
+
+    def create(session_id:, command:, args: [], env: [], cwd: nil, output_byte_limit: 1_048_576)
+      cmd = [command, *args].map(&:to_s)
+      env_hash = env.to_h { |e| [e["name"] || e[:name], e["value"] || e[:value]] }
+      workdir = cwd || Dir.pwd
+
+      stdin, stdout, stderr, wait_thr = Open3.popen3(env_hash, *cmd, chdir: workdir)
+
+      terminal_id = @mutex.synchronize do
+        id = "term_#{@next_id}"
+        @next_id += 1
+        @terminals[id] = {
+          stdin: stdin,
+          stdout: stdout,
+          stderr: stderr,
+          wait_thr: wait_thr,
+          output: +"",
+          output_byte_limit: output_byte_limit,
+          truncated: false,
+          exit_status: nil
+        }
+        id
+      end
+
+      start_output_reader(terminal_id)
+      terminal_id
+    end
+
+    def output(terminal_id)
+      @mutex.synchronize do
+        t = @terminals[terminal_id]
+        raise ProtocolError, "Unknown terminal: #{terminal_id}" unless t
+
+        {
+          output: t[:output].dup,
+          truncated: t[:truncated],
+          exitStatus: t[:exit_status]
+        }.compact
+      end
+    end
+
+    def wait_for_exit(terminal_id)
+      t = @mutex.synchronize { @terminals[terminal_id] }
+      raise ProtocolError, "Unknown terminal: #{terminal_id}" unless t
+
+      status = t[:wait_thr].value
+
+      @mutex.synchronize do
+        t = @terminals[terminal_id]
+        t[:exit_status] = format_exit_status(status) if t
+      end
+
+      format_exit_status(status)
+    end
+
+    def kill(terminal_id)
+      t = @mutex.synchronize { @terminals[terminal_id] }
+      raise ProtocolError, "Unknown terminal: #{terminal_id}" unless t
+
+      return unless t[:wait_thr]&.alive?
+
+      Process.kill("TERM", t[:wait_thr].pid)
+    rescue Errno::ESRCH
+      # already dead
+    end
+
+    def release(terminal_id)
+      @mutex.synchronize do
+        t = @terminals.delete(terminal_id)
+        return unless t
+
+        t[:stdin]&.close rescue nil
+        t[:stdout]&.close rescue nil
+        t[:stderr]&.close rescue nil
+
+        if t[:wait_thr]&.alive?
+          Process.kill("TERM", t[:wait_thr].pid) rescue nil
+        end
+      end
+    end
+
+    private
+
+    def start_output_reader(terminal_id)
+      Thread.new do
+        t = @mutex.synchronize { @terminals[terminal_id] }
+        next unless t
+
+        stdout = t[:stdout]
+        stderr = t[:stderr]
+        limit = t[:output_byte_limit]
+        wait_thr = t[:wait_thr]
+
+        append_output = lambda do |text|
+          @mutex.synchronize do
+            t = @terminals[terminal_id]
+            return unless t
+
+            t[:output] << text
+            while t[:output].bytesize > limit && (idx = t[:output].index("\n"))
+              t[:output] = t[:output].byteslice((idx + 1)..) || +""
+              t[:truncated] = true
+            end
+          end
+        end
+
+        threads = [
+          Thread.new { stdout.each_line { |line| append_output.call(line) } rescue IOError },
+          Thread.new { stderr.each_line { |line| append_output.call("[stderr] #{line}") } rescue IOError }
+        ]
+        threads.each(&:join)
+
+        @mutex.synchronize do
+          t = @terminals[terminal_id]
+          return unless t
+
+          status = wait_thr.value
+          t[:exit_status] = format_exit_status(status)
+        end
+      end
+    end
+
+    def format_exit_status(process_status)
+      return nil unless process_status
+
+      {
+        exitCode: process_status.exitstatus,
+        signal: process_status.termsig
+      }.compact
+    end
+  end
+end

--- a/test/test_terminal_handlers.rb
+++ b/test/test_terminal_handlers.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestTerminalHandlers < Minitest::Test
+  def setup
+    @pm = MockProcessManager.new
+    @pm.start
+    @rpc = AcpClient::JsonRpc.new
+    @terminal_manager = AcpClient::TerminalManager.new
+    @handler = AcpClient::ResponseHandler.new(
+      process_manager: @pm,
+      json_rpc: @rpc,
+      terminal_manager: @terminal_manager
+    )
+  end
+
+  def teardown
+    @pm.close
+  end
+
+  def test_terminal_create_returns_terminal_id
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 20,
+      "method" => "terminal/create",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "command" => "echo",
+        "args" => ["hello"]
+      }
+    }.to_json)
+
+    sleep 0.2
+    resp = @pm.messages_sent.find { |m| m[:id] == 20 }
+    assert resp, "Expected response for request id 20"
+    assert resp[:result][:terminalId].start_with?("term_")
+  end
+
+  def test_terminal_output_returns_output
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 21,
+      "method" => "terminal/create",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "command" => "echo",
+        "args" => ["hello world"]
+      }
+    }.to_json)
+
+    sleep 0.3
+    create_resp = @pm.messages_sent.find { |m| m[:id] == 21 }
+    terminal_id = create_resp[:result][:terminalId]
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 22,
+      "method" => "terminal/output",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "terminalId" => terminal_id
+      }
+    }.to_json)
+
+    sleep 0.2
+    output_resp = @pm.messages_sent.find { |m| m[:id] == 22 }
+    assert output_resp, "Expected response for request id 22"
+    assert_includes output_resp[:result][:output], "hello world"
+  end
+
+  def test_terminal_release
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 23,
+      "method" => "terminal/create",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "command" => "echo",
+        "args" => ["x"]
+      }
+    }.to_json)
+
+    sleep 0.2
+    create_resp = @pm.messages_sent.find { |m| m[:id] == 23 }
+    terminal_id = create_resp[:result][:terminalId]
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 24,
+      "method" => "terminal/release",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "terminalId" => terminal_id
+      }
+    }.to_json)
+
+    sleep 0.1
+    release_resp = @pm.messages_sent.find { |m| m[:id] == 24 }
+    assert release_resp, "Expected response for request id 24"
+    assert_nil release_resp[:result]
+  end
+
+  private
+
+  def init_and_session_flow(pm)
+    pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 0, "result" => {"protocolVersion" => 1, "agentCapabilities" => {}}}.to_json)
+    pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 1, "result" => {"sessionId" => "sess_test123"}}.to_json)
+  end
+end


### PR DESCRIPTION
## 概要
ACP の terminal/* メソッドに対応しました。Agent が Client 経由でシェルコマンドを実行できるようになります。

## 変更内容

### TerminalManager
- `terminal/create`: コマンド起動、terminalId を即時返却
- `terminal/output`: 出力と exitStatus を取得
- `terminal/wait_for_exit`: プロセス終了を待機
- `terminal/kill`: プロセスを終了
- `terminal/release`: リソース解放

### 実装詳細
- Open3.popen3 でサブプロセス起動
- stdout/stderr を並行読み取り
- outputByteLimit による出力の切り詰め（先頭から削除）
- env, cwd 対応

### テスト
- test/test_terminal_handlers.rb を追加

Made with [Cursor](https://cursor.com)