### PR TITLE
fix: Gemfile.lock のバージョン不一致を修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acp_client_rb (0.1.0)
+    acp_client_rb (0.0.1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
## Summary
- `Gemfile.lock` の PATH セクションに `acp_client_rb (0.1.0)` と記載されていたが、gemspec の VERSION は `"0.0.1"` であり、CHECKSUMS セクションの `acp_client_rb (0.0.1)` とも不一致だった
- `bundle install` で `Gemfile.lock` を再生成し、PATH セクションのバージョンを `0.0.1` に修正
- これにより Bundler の frozen mode でのバージョン不一致エラーが解消される

## Test plan
- [ ] CI (`bundle install` + テスト) が通ることを確認
- [ ] マージ後、PR #3 をリベースして CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)