### PR TITLE
fix: Standard lint エラーを修正

### DIFF
--- a/acp_client_rb.gemspec
+++ b/acp_client_rb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/nissyi-gh/acp_client_rb"
-    spec.metadata["changelog_uri"] = "https://github.com/nissyi-gh/acp_client_rb/blob/main/CHANGELOG.md"
+  spec.metadata["changelog_uri"] = "https://github.com/nissyi-gh/acp_client_rb/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/lib/acp_client/json_rpc.rb
+++ b/lib/acp_client/json_rpc.rb
@@ -27,7 +27,7 @@ module AcpClient
         params: {
           protocolVersion: 1,
           clientCapabilities: {
-            fs: { readTextFile: true, writeTextFile: true },
+            fs: {readTextFile: true, writeTextFile: true},
             terminal: true
           },
           clientInfo: {
@@ -59,7 +59,7 @@ module AcpClient
         params: {
           sessionId: session_id,
           prompt: [
-            { type: "text", text: prompt_text }
+            {type: "text", text: prompt_text}
           ]
         }
       }

--- a/lib/acp_client/process_manager.rb
+++ b/lib/acp_client/process_manager.rb
@@ -40,12 +40,28 @@ module AcpClient
     def shutdown
       return unless @running
 
-      @stdin&.close rescue nil
-      @stdout&.close rescue nil
-      @stderr&.close rescue nil
+      begin
+        @stdin&.close
+      rescue
+        nil
+      end
+      begin
+        @stdout&.close
+      rescue
+        nil
+      end
+      begin
+        @stderr&.close
+      rescue
+        nil
+      end
 
       if @wait_thr&.alive?
-        Process.kill("TERM", @wait_thr.pid) rescue nil
+        begin
+          Process.kill("TERM", @wait_thr.pid)
+        rescue
+          nil
+        end
       end
 
       @running = false

--- a/lib/acp_client/response_handler.rb
+++ b/lib/acp_client/response_handler.rb
@@ -52,8 +52,16 @@ module AcpClient
     end
 
     def stop_threads
-      @reader_thread&.kill rescue nil
-      @stderr_thread&.kill rescue nil
+      begin
+        @reader_thread&.kill
+      rescue
+        nil
+      end
+      begin
+        @stderr_thread&.kill
+      rescue
+        nil
+      end
     end
 
     def wait_for_ready

--- a/lib/acp_client/terminal_manager.rb
+++ b/lib/acp_client/terminal_manager.rb
@@ -80,12 +80,28 @@ module AcpClient
         t = @terminals.delete(terminal_id)
         return unless t
 
-        t[:stdin]&.close rescue nil
-        t[:stdout]&.close rescue nil
-        t[:stderr]&.close rescue nil
+        begin
+          t[:stdin]&.close
+        rescue
+          nil
+        end
+        begin
+          t[:stdout]&.close
+        rescue
+          nil
+        end
+        begin
+          t[:stderr]&.close
+        rescue
+          nil
+        end
 
         if t[:wait_thr]&.alive?
-          Process.kill("TERM", t[:wait_thr].pid) rescue nil
+          begin
+            Process.kill("TERM", t[:wait_thr].pid)
+          rescue
+            nil
+          end
         end
       end
     end
@@ -116,8 +132,20 @@ module AcpClient
         end
 
         threads = [
-          Thread.new { stdout.each_line { |line| append_output.call(line) } rescue IOError },
-          Thread.new { stderr.each_line { |line| append_output.call("[stderr] #{line}") } rescue IOError }
+          Thread.new {
+            begin
+              stdout.each_line { |line| append_output.call(line) }
+            rescue
+              IOError
+            end
+          },
+          Thread.new {
+            begin
+              stderr.each_line { |line| append_output.call("[stderr] #{line}") }
+            rescue
+              IOError
+            end
+          }
         ]
         threads.each(&:join)
 


### PR DESCRIPTION
## Summary
- `bundle exec rake standard:fix` で CI で検出されていた lint エラーを修正
- gemspec のインデント不整合 (`Layout/IndentationConsistency`)
- ハッシュリテラル内のスペース (`Layout/SpaceInsideHashLiteralBraces`)
- `rescue` modifier の展開 (`Style/RescueModifier`)

## Test plan
- [x] CI (テスト + Standard lint) が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)