### PR TITLE
Milestone 4: session/update 完全対応

### DIFF
--- a/lib/acp_client/response_handler.rb
+++ b/lib/acp_client/response_handler.rb
@@ -32,6 +32,12 @@ module AcpClient
       @on_text_chunk = nil
       @on_fs_read_text_file = nil
       @on_fs_write_text_file = nil
+      @on_plan = nil
+      @on_tool_call = nil
+      @on_tool_call_update = nil
+      @on_session_info_update = nil
+      @on_current_mode_update = nil
+      @on_user_message_chunk = nil
     end
 
     def on_text_chunk(&block)
@@ -44,6 +50,30 @@ module AcpClient
 
     def on_fs_write_text_file(&block)
       @on_fs_write_text_file = block
+    end
+
+    def on_plan(&block)
+      @on_plan = block
+    end
+
+    def on_tool_call(&block)
+      @on_tool_call = block
+    end
+
+    def on_tool_call_update(&block)
+      @on_tool_call_update = block
+    end
+
+    def on_session_info_update(&block)
+      @on_session_info_update = block
+    end
+
+    def on_current_mode_update(&block)
+      @on_current_mode_update = block
+    end
+
+    def on_user_message_chunk(&block)
+      @on_user_message_chunk = block
     end
 
     def start_threads
@@ -297,7 +327,57 @@ module AcpClient
         end
       when "agent_message_chunk"
         handle_agent_message_chunk(sid, upd)
+      when "plan"
+        handle_plan(sid, upd)
+      when "tool_call"
+        handle_tool_call(sid, upd)
+      when "tool_call_update"
+        handle_tool_call_update(sid, upd)
+      when "session_info_update"
+        handle_session_info_update(sid, upd)
+      when "current_mode_update"
+        handle_current_mode_update(sid, upd)
+      when "user_message_chunk"
+        handle_user_message_chunk(sid, upd)
       end
+    end
+
+    def handle_plan(sid, upd)
+      entries = upd["entries"] || []
+      @on_plan&.call(sid, entries)
+    end
+
+    def handle_tool_call(sid, upd)
+      tool_call_id = upd["toolCallId"]
+      title = upd["title"]
+      kind = upd["kind"]
+      status = upd["status"]
+      content = upd["content"]
+      @on_tool_call&.call(sid, tool_call_id: tool_call_id, title: title, kind: kind, status: status, content: content)
+    end
+
+    def handle_tool_call_update(sid, upd)
+      tool_call_id = upd["toolCallId"]
+      status = upd["status"]
+      content = upd["content"]
+      @on_tool_call_update&.call(sid, tool_call_id: tool_call_id, status: status, content: content)
+    end
+
+    def handle_session_info_update(sid, upd)
+      title = upd["title"]
+      updated_at = upd["updatedAt"]
+      meta = upd["_meta"]
+      @on_session_info_update&.call(sid, title: title, updated_at: updated_at, meta: meta)
+    end
+
+    def handle_current_mode_update(sid, upd)
+      mode = upd["mode"]
+      @on_current_mode_update&.call(sid, mode)
+    end
+
+    def handle_user_message_chunk(sid, upd)
+      content = upd["content"] || {}
+      @on_user_message_chunk&.call(sid, content)
     end
 
     def handle_agent_message_chunk(sid, upd)

--- a/test/test_session_update.rb
+++ b/test/test_session_update.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestSessionUpdate < Minitest::Test
+  def setup
+    @pm = MockProcessManager.new
+    @pm.start
+    @rpc = AcpClient::JsonRpc.new
+    @handler = AcpClient::ResponseHandler.new(process_manager: @pm, json_rpc: @rpc)
+  end
+
+  def teardown
+    @pm.close
+  end
+
+  def test_plan_callback
+    plans = []
+    @handler.on_plan { |sid, entries| plans << [sid, entries] }
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "method" => "session/update",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "update" => {
+          "sessionUpdate" => "plan",
+          "entries" => [
+            {"content" => "Step 1", "priority" => "high", "status" => "pending"},
+            {"content" => "Step 2", "priority" => "low", "status" => "pending"}
+          ]
+        }
+      }
+    }.to_json)
+
+    sleep 0.1
+    assert_equal 1, plans.size
+    assert_equal "sess_test123", plans[0][0]
+    assert_equal 2, plans[0][1].size
+    assert_equal "Step 1", plans[0][1][0]["content"]
+  end
+
+  def test_tool_call_callback
+    tool_calls = []
+    @handler.on_tool_call { |sid, data| tool_calls << [sid, data] }
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "method" => "session/update",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "update" => {
+          "sessionUpdate" => "tool_call",
+          "toolCallId" => "call_001",
+          "title" => "Running tests",
+          "kind" => "execute",
+          "status" => "pending"
+        }
+      }
+    }.to_json)
+
+    sleep 0.1
+    assert_equal 1, tool_calls.size
+    assert_equal "sess_test123", tool_calls[0][0]
+    assert_equal "call_001", tool_calls[0][1][:tool_call_id]
+    assert_equal "Running tests", tool_calls[0][1][:title]
+    assert_equal "execute", tool_calls[0][1][:kind]
+  end
+
+  def test_tool_call_update_callback
+    updates = []
+    @handler.on_tool_call_update { |sid, data| updates << [sid, data] }
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "method" => "session/update",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "update" => {
+          "sessionUpdate" => "tool_call_update",
+          "toolCallId" => "call_001",
+          "status" => "completed",
+          "content" => [{"type" => "content", "content" => {"type" => "text", "text" => "Done"}}]
+        }
+      }
+    }.to_json)
+
+    sleep 0.1
+    assert_equal 1, updates.size
+    assert_equal "completed", updates[0][1][:status]
+    assert_equal 1, updates[0][1][:content].size
+  end
+
+  def test_session_info_update_callback
+    infos = []
+    @handler.on_session_info_update { |sid, data| infos << [sid, data] }
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "method" => "session/update",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "update" => {
+          "sessionUpdate" => "session_info_update",
+          "title" => "New session title"
+        }
+      }
+    }.to_json)
+
+    sleep 0.1
+    assert_equal 1, infos.size
+    assert_equal "New session title", infos[0][1][:title]
+  end
+
+  def test_user_message_chunk_callback
+    chunks = []
+    @handler.on_user_message_chunk { |sid, content| chunks << [sid, content] }
+    @handler.start_threads
+
+    init_and_session_flow(@pm)
+    @handler.wait_for_ready
+
+    @pm.inject_stdout_line({
+      "method" => "session/update",
+      "params" => {
+        "sessionId" => "sess_test123",
+        "update" => {
+          "sessionUpdate" => "user_message_chunk",
+          "content" => {"type" => "text", "text" => "User said this"}
+        }
+      }
+    }.to_json)
+
+    sleep 0.1
+    assert_equal 1, chunks.size
+    assert_equal "User said this", chunks[0][1]["text"]
+  end
+
+  private
+
+  def init_and_session_flow(pm)
+    pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 0, "result" => {"protocolVersion" => 1, "agentCapabilities" => {}}}.to_json)
+    pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 1, "result" => {"sessionId" => "sess_test123"}}.to_json)
+  end
+end


### PR DESCRIPTION
## 概要
session/update の全種類の通知をコールバックで受け取れるようにしました。

## 対応した sessionUpdate タイプ

- `plan` - エージェントの実行計画
- `tool_call` - ツール呼び出しの開始
- `tool_call_update` - ツール呼び出しの進行・完了
- `session_info_update` - セッションタイトル・メタデータの更新
- `current_mode_update` - セッションモードの更新
- `user_message_chunk` - session/load 時のリプレイ用

## コールバック API

```ruby
response_handler.on_plan { |session_id, entries| ... }
response_handler.on_tool_call { |session_id, data| ... }
response_handler.on_tool_call_update { |session_id, data| ... }
response_handler.on_session_info_update { |session_id, data| ... }
response_handler.on_current_mode_update { |session_id, mode| ... }
response_handler.on_user_message_chunk { |session_id, content| ... }
```

Made with [Cursor](https://cursor.com)