### PR TITLE
feat: Milestone 6 - セッション管理の拡張 (session/load, session/list)

### DIFF
--- a/lib/acp_client/client.rb
+++ b/lib/acp_client/client.rb
@@ -12,6 +12,11 @@ module AcpClient
       @fs_write_text_file = fs_write_text_file
     end
 
+    def list_session_capability?
+      caps = agent_capabilities
+      caps["list"] == true || caps.dig("sessionCapabilities", "list") == true
+    end
+
     def interactive_session!
       connect
       run_interactive_loop
@@ -19,12 +24,16 @@ module AcpClient
       shutdown
     end
 
-    def connect
+    def connect(load_session_id: nil, create_session: true, cwd: Dir.pwd, mcp_servers: [])
       @process_manager.start
 
       @response_handler = ResponseHandler.new(
         process_manager: @process_manager,
-        json_rpc: @json_rpc
+        json_rpc: @json_rpc,
+        load_session_id: load_session_id,
+        create_session: create_session,
+        cwd: cwd,
+        mcp_servers: mcp_servers
       )
 
       @response_handler.on_fs_read_text_file(&@fs_read_text_file) if @fs_read_text_file
@@ -41,6 +50,46 @@ module AcpClient
       @process_manager.send_message(message)
 
       @response_handler.wait_for_ready
+    end
+
+    def list_sessions(cwd: nil, cursor: nil)
+      raise SessionError, "Not connected" unless @response_handler
+      unless list_session_capability?
+        raise SessionError, "Agent does not support session/list (sessionCapabilities.list)"
+      end
+
+      request_id = @json_rpc.next_id
+      @response_handler.register_pending_request(request_id)
+
+      message = @json_rpc.session_list_message(request_id: request_id, cwd: cwd, cursor: cursor)
+      @process_manager.send_message(message)
+
+      result = @response_handler.wait_for_pending_response(request_id)
+      {
+        sessions: result["sessions"] || [],
+        next_cursor: result["nextCursor"]
+      }
+    end
+
+    def load_session(session_id, cwd: Dir.pwd, mcp_servers: [])
+      raise SessionError, "Not connected" unless @response_handler
+      caps = agent_capabilities
+      unless caps["loadSession"] == true || caps.dig("sessionCapabilities", "loadSession") == true
+        raise SessionError, "Agent does not support session/load (loadSession)"
+      end
+
+      request_id = @json_rpc.next_id
+      @response_handler.register_session_load(request_id, session_id)
+
+      message = @json_rpc.session_load_message(
+        request_id: request_id,
+        session_id: session_id,
+        cwd: cwd,
+        mcp_servers: mcp_servers
+      )
+      @process_manager.send_message(message)
+
+      @response_handler.wait_for_session
     end
 
     def send_prompt(text)

--- a/lib/acp_client/json_rpc.rb
+++ b/lib/acp_client/json_rpc.rb
@@ -75,6 +75,31 @@ module AcpClient
       }
     end
 
+    def session_load_message(request_id:, session_id:, cwd: Dir.pwd, mcp_servers: [])
+      {
+        jsonrpc: JSON_RPC_VERSION,
+        id: request_id,
+        method: "session/load",
+        params: {
+          sessionId: session_id,
+          cwd: cwd,
+          mcpServers: mcp_servers
+        }
+      }
+    end
+
+    def session_list_message(request_id:, cwd: nil, cursor: nil)
+      params = {}
+      params[:cwd] = cwd if cwd
+      params[:cursor] = cursor if cursor
+      {
+        jsonrpc: JSON_RPC_VERSION,
+        id: request_id,
+        method: "session/list",
+        params: params
+      }
+    end
+
     def generate(id:, method:, params:)
       {
         jsonrpc: JSON_RPC_VERSION,

--- a/lib/acp_client/response_handler.rb
+++ b/lib/acp_client/response_handler.rb
@@ -6,19 +6,26 @@ module AcpClient
   class ResponseHandler
     attr_reader :session_id, :initialized, :agent_capabilities
 
-    def initialize(process_manager:, json_rpc:, terminal_manager: nil)
+    def initialize(process_manager:, json_rpc:, terminal_manager: nil, load_session_id: nil, create_session: true, cwd: Dir.pwd, mcp_servers: [])
       @process_manager = process_manager
       @json_rpc = json_rpc
       @terminal_manager = terminal_manager || TerminalManager.new
+      @load_session_id = load_session_id
+      @create_session = create_session
+      @cwd = cwd
+      @mcp_servers = mcp_servers
 
       @mutex = Mutex.new
       @ready = ConditionVariable.new
+      @session_ready_cv = ConditionVariable.new
       @turn_done = ConditionVariable.new
 
       @session_id = nil
       @initialized = false
+      @session_ready = false
       @agent_capabilities = {}
       @fatal_error = nil
+      @session_load_request_id = nil
 
       @buffers = Hash.new { |h, sid| h[sid] = MessageBuffer.new }
       @available_commands_by_session = {}
@@ -26,6 +33,7 @@ module AcpClient
       @prompt_session_by_request_id = {}
       @active_turn_request_id = nil
       @error_by_request_id = {}
+      @pending_requests = {}
 
       @reader_thread = nil
       @stderr_thread = nil
@@ -119,6 +127,13 @@ module AcpClient
       end
     end
 
+    def wait_for_session
+      @mutex.synchronize do
+        @session_ready_cv.wait(@mutex) until @session_ready || @fatal_error
+        raise @fatal_error if @fatal_error
+      end
+    end
+
     def wait_for_turn_completion(request_id)
       @mutex.synchronize do
         @turn_done.wait(@mutex) while @active_turn_request_id == request_id
@@ -138,6 +153,36 @@ module AcpClient
 
     def current_session_id
       @mutex.synchronize { @session_id }
+    end
+
+    def register_pending_request(request_id)
+      @mutex.synchronize do
+        @pending_requests[request_id] = {result: nil, error: nil, cond: ConditionVariable.new}
+      end
+    end
+
+    def wait_for_pending_response(request_id)
+      @mutex.synchronize do
+        pr = @pending_requests[request_id]
+        raise ArgumentError, "Request #{request_id} not registered" unless pr
+        pr[:cond].wait(@mutex) until pr[:result] || pr[:error]
+        result = pr[:result]
+        error = pr[:error]
+        @pending_requests.delete(request_id)
+        raise error if error
+        result
+      end
+    end
+
+    def session_load_request_id
+      @mutex.synchronize { @session_load_request_id }
+    end
+
+    def register_session_load(request_id, session_id)
+      @mutex.synchronize do
+        @session_load_request_id = request_id
+        @load_session_id = session_id
+      end
     end
 
     private
@@ -467,6 +512,24 @@ module AcpClient
         return
       end
 
+      if id && @mutex.synchronize { id == @session_load_request_id }
+        if msg["error"]
+          handle_error_response(id, msg["error"], fatal: true)
+        else
+          handle_session_load_response
+        end
+        return
+      end
+
+      if id && @mutex.synchronize { @pending_requests.key?(id) }
+        if msg["error"]
+          complete_pending_request(id, nil, protocol_error_from(msg["error"]))
+        else
+          complete_pending_request(id, msg["result"], nil)
+        end
+        return
+      end
+
       if msg["result"].is_a?(Hash) && msg["result"].key?("stopReason")
         handle_prompt_response(id, msg["result"])
         return
@@ -477,12 +540,44 @@ module AcpClient
       end
     end
 
+    def protocol_error_from(error)
+      code = error["code"]
+      message = error["message"] || error.to_s
+      data = error["data"]
+      ProtocolError.new(message, code: code, data: data)
+    end
+
     def handle_initialize_response(result = nil)
+      caps = nil
       @mutex.synchronize do
         @agent_capabilities = (result || {}).fetch("agentCapabilities", {})
+        caps = @agent_capabilities
       end
-      message = @json_rpc.session_new_message
-      @process_manager.send_message(message)
+      unless @create_session
+        @mutex.synchronize do
+          @initialized = true
+          @ready.broadcast
+        end
+        return
+      end
+      if @load_session_id && load_session_capability?(caps)
+        req_id = @json_rpc.next_id
+        @mutex.synchronize { @session_load_request_id = req_id }
+        message = @json_rpc.session_load_message(
+          request_id: req_id,
+          session_id: @load_session_id,
+          cwd: @cwd,
+          mcp_servers: @mcp_servers
+        )
+        @process_manager.send_message(message)
+      else
+        message = @json_rpc.session_new_message(cwd: @cwd, mcp_servers: @mcp_servers)
+        @process_manager.send_message(message)
+      end
+    end
+
+    def load_session_capability?(caps)
+      caps["loadSession"] == true || caps.dig("sessionCapabilities", "loadSession") == true
     end
 
     def handle_session_new_response(result)
@@ -492,11 +587,37 @@ module AcpClient
       @mutex.synchronize do
         @session_id = sid
         @initialized = true
+        @session_ready = true
         @ready.broadcast
+        @session_ready_cv.broadcast
       end
 
       puts "\n[info] session_id=#{sid}"
       puts "[info] You can now type messages. Type 'exit' to quit."
+    end
+
+    def handle_session_load_response
+      @mutex.synchronize do
+        @session_id = @load_session_id
+        @initialized = true
+        @session_ready = true
+        @ready.broadcast
+        @session_ready_cv.broadcast
+      end
+
+      puts "\n[info] session_id=#{@load_session_id} (loaded)"
+      puts "[info] You can now type messages. Type 'exit' to quit."
+    end
+
+    def complete_pending_request(id, result, error)
+      @mutex.synchronize do
+        pr = @pending_requests[id]
+        if pr
+          pr[:result] = result
+          pr[:error] = error
+          pr[:cond].broadcast
+        end
+      end
     end
 
     def handle_prompt_response(id, result)
@@ -517,14 +638,14 @@ module AcpClient
       $stdout.flush
     end
 
-    def handle_error_response(id, error)
+    def handle_error_response(id, error, fatal: false)
       code = error["code"]
       message = error["message"] || error.to_s
       data = error["data"]
       protocol_error = ProtocolError.new(message, code: code, data: data)
 
       @mutex.synchronize do
-        if id == JsonRpc::INITIALIZE_ID || id == JsonRpc::SESSION_NEW_ID
+        if fatal || id == JsonRpc::INITIALIZE_ID || id == JsonRpc::SESSION_NEW_ID
           @fatal_error = protocol_error
           @ready.broadcast
         else

--- a/lib/acp_client/response_handler.rb
+++ b/lib/acp_client/response_handler.rb
@@ -560,20 +560,19 @@ module AcpClient
         end
         return
       end
-      if @load_session_id && load_session_capability?(caps)
+      message = if @load_session_id && load_session_capability?(caps)
         req_id = @json_rpc.next_id
         @mutex.synchronize { @session_load_request_id = req_id }
-        message = @json_rpc.session_load_message(
+        @json_rpc.session_load_message(
           request_id: req_id,
           session_id: @load_session_id,
           cwd: @cwd,
           mcp_servers: @mcp_servers
         )
-        @process_manager.send_message(message)
       else
-        message = @json_rpc.session_new_message(cwd: @cwd, mcp_servers: @mcp_servers)
-        @process_manager.send_message(message)
+        @json_rpc.session_new_message(cwd: @cwd, mcp_servers: @mcp_servers)
       end
+      @process_manager.send_message(message)
     end
 
     def load_session_capability?(caps)

--- a/test/test_json_rpc.rb
+++ b/test/test_json_rpc.rb
@@ -53,6 +53,34 @@ class TestJsonRpc < Minitest::Test
     assert_equal "sess_xyz", msg[:params][:sessionId]
   end
 
+  def test_session_load_message
+    msg = @rpc.session_load_message(request_id: 5, session_id: "sess_load1", cwd: "/home", mcp_servers: [])
+
+    assert_equal "2.0", msg[:jsonrpc]
+    assert_equal 5, msg[:id]
+    assert_equal "session/load", msg[:method]
+    assert_equal "sess_load1", msg[:params][:sessionId]
+    assert_equal "/home", msg[:params][:cwd]
+    assert_equal [], msg[:params][:mcpServers]
+  end
+
+  def test_session_list_message
+    msg = @rpc.session_list_message(request_id: 6, cwd: "/tmp", cursor: "next123")
+
+    assert_equal "2.0", msg[:jsonrpc]
+    assert_equal 6, msg[:id]
+    assert_equal "session/list", msg[:method]
+    assert_equal "/tmp", msg[:params][:cwd]
+    assert_equal "next123", msg[:params][:cursor]
+  end
+
+  def test_session_list_message_empty_params
+    msg = @rpc.session_list_message(request_id: 7)
+
+    assert_equal "session/list", msg[:method]
+    assert_equal({}, msg[:params])
+  end
+
   def test_next_id_increments
     assert_equal 2, @rpc.next_id
     assert_equal 3, @rpc.next_id

--- a/test/test_session_management.rb
+++ b/test/test_session_management.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestSessionManagement < Minitest::Test
+  def setup
+    @pm = MockProcessManager.new
+    @pm.start
+    @rpc = AcpClient::JsonRpc.new
+  end
+
+  def teardown
+    @pm.close
+  end
+
+  def test_connect_with_load_session_id_sends_session_load_when_capability
+    handler = AcpClient::ResponseHandler.new(
+      process_manager: @pm,
+      json_rpc: @rpc,
+      load_session_id: "sess_existing",
+      cwd: "/home",
+      mcp_servers: []
+    )
+    handler.start_threads
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 0,
+      "result" => {
+        "protocolVersion" => 1,
+        "agentCapabilities" => {"loadSession" => true}
+      }
+    }.to_json)
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 2,
+      "result" => nil
+    }.to_json)
+
+    handler.wait_for_ready
+
+    assert_equal "sess_existing", handler.session_id
+    assert handler.initialized
+    assert_equal 1, @pm.messages_sent.size, "handler sends session/load after init response"
+    load_msg = @pm.messages_sent[0]
+    assert_equal "session/load", load_msg[:method]
+    assert_equal "sess_existing", load_msg[:params][:sessionId]
+    assert_equal "/home", load_msg[:params][:cwd]
+  end
+
+  def test_connect_with_load_session_id_sends_session_new_when_no_capability
+    handler = AcpClient::ResponseHandler.new(
+      process_manager: @pm,
+      json_rpc: @rpc,
+      load_session_id: "sess_existing"
+    )
+    handler.start_threads
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 0,
+      "result" => {
+        "protocolVersion" => 1,
+        "agentCapabilities" => {}
+      }
+    }.to_json)
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "result" => {"sessionId" => "sess_new123"}
+    }.to_json)
+
+    handler.wait_for_ready
+
+    assert_equal "sess_new123", handler.session_id
+    assert_equal "session/new", @pm.messages_sent[0][:method]
+  end
+
+  def test_connect_create_session_false_does_not_send_session_new
+    handler = AcpClient::ResponseHandler.new(
+      process_manager: @pm,
+      json_rpc: @rpc,
+      create_session: false
+    )
+    handler.start_threads
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 0,
+      "result" => {
+        "protocolVersion" => 1,
+        "agentCapabilities" => {}
+      }
+    }.to_json)
+
+    handler.wait_for_ready
+
+    assert_nil handler.session_id
+    assert handler.initialized
+    assert_equal 0, @pm.messages_sent.size, "handler sends nothing when create_session false"
+  end
+
+  def test_list_sessions_pending_request
+    handler = AcpClient::ResponseHandler.new(
+      process_manager: @pm,
+      json_rpc: @rpc,
+      create_session: false
+    )
+    handler.start_threads
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 0,
+      "result" => {
+        "protocolVersion" => 1,
+        "agentCapabilities" => {"sessionCapabilities" => {"list" => true}}
+      }
+    }.to_json)
+    handler.wait_for_ready
+
+    request_id = @rpc.next_id
+    handler.register_pending_request(request_id)
+
+    msg = @rpc.session_list_message(request_id: request_id, cwd: "/tmp")
+    @pm.send_message(msg)
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => request_id,
+      "result" => {
+        "sessions" => [{"id" => "s1", "title" => "Session 1"}],
+        "nextCursor" => "cursor2"
+      }
+    }.to_json)
+
+    result = handler.wait_for_pending_response(request_id)
+    assert_equal [{"id" => "s1", "title" => "Session 1"}], result["sessions"]
+    assert_equal "cursor2", result["nextCursor"]
+  end
+
+  def test_load_session_after_create_session_false
+    handler = AcpClient::ResponseHandler.new(
+      process_manager: @pm,
+      json_rpc: @rpc,
+      create_session: false
+    )
+    handler.start_threads
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 0,
+      "result" => {
+        "protocolVersion" => 1,
+        "agentCapabilities" => {"loadSession" => true}
+      }
+    }.to_json)
+    handler.wait_for_ready
+
+    request_id = @rpc.next_id
+    handler.register_session_load(request_id, "sess_to_load")
+
+    msg = @rpc.session_load_message(
+      request_id: request_id,
+      session_id: "sess_to_load",
+      cwd: Dir.pwd,
+      mcp_servers: []
+    )
+    @pm.send_message(msg)
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => request_id,
+      "result" => nil
+    }.to_json)
+
+    handler.wait_for_session
+
+    assert_equal "sess_to_load", handler.session_id
+  end
+
+  def test_session_load_error_raises
+    handler = AcpClient::ResponseHandler.new(
+      process_manager: @pm,
+      json_rpc: @rpc,
+      load_session_id: "sess_missing"
+    )
+    handler.start_threads
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 0,
+      "result" => {
+        "protocolVersion" => 1,
+        "agentCapabilities" => {"loadSession" => true}
+      }
+    }.to_json)
+
+    @pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 2,
+      "error" => {"code" => -32602, "message" => "Session not found"}
+    }.to_json)
+
+    assert_raises(AcpClient::ProtocolError) do
+      handler.wait_for_ready
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Milestone 6: セッション管理の拡張を実装しました。

## 変更内容

### session/load
- 既存セッションの復元（`loadSession` capability を確認）
- `connect(load_session_id: "xxx")` で接続時にロード
- `load_session(session_id)` で `create_session: false` 接続後にロード

### session/list
- セッション一覧取得（`sessionCapabilities.list` を確認）
- `list_sessions(cwd: nil, cursor: nil)` で `{sessions:, next_cursor:}` を返却

### Client API
- `connect(load_session_id:, create_session:, cwd:, mcp_servers:)`
- `list_sessions(cwd:, cursor:)`
- `load_session(session_id, cwd:, mcp_servers:)`
- `list_session_capability?`

### ResponseHandler
- pending request 機構（`register_pending_request`, `wait_for_pending_response`）
- `wait_for_session`（`load_session` 完了待ち）
- `create_session: false` でセッションなし初期化

## テスト
- `test/test_session_management.rb` を追加
- `test/test_json_rpc.rb` に `session_load_message`, `session_list_message` のテストを追加

全 42 テストパス

Made with [Cursor](https://cursor.com)