### PR TITLE
feat: Milestone 7 - プロンプトの拡張コンテンツ (Issue #10)

### DIFF
--- a/lib/acp_client/client.rb
+++ b/lib/acp_client/client.rb
@@ -4,9 +4,9 @@ module AcpClient
   class Client
     attr_reader :json_rpc, :process_manager, :response_handler
 
-    def initialize(fs_read_text_file: nil, fs_write_text_file: nil)
+    def initialize(fs_read_text_file: nil, fs_write_text_file: nil, process_manager: nil)
       @json_rpc = JsonRpc.new
-      @process_manager = ProcessManager.new
+      @process_manager = process_manager || ProcessManager.new
       @response_handler = nil
       @fs_read_text_file = fs_read_text_file
       @fs_write_text_file = fs_write_text_file
@@ -92,9 +92,13 @@ module AcpClient
       @response_handler.wait_for_session
     end
 
-    def send_prompt(text)
+    # @param prompt [String, Array<Hash>] Text or ContentBlock array (text, image, audio, resource, resource_link)
+    def send_prompt(prompt)
       session_id = @response_handler.current_session_id
       raise SessionError, "Session not ready" unless session_id
+
+      content_blocks = normalize_prompt(prompt)
+      validate_prompt_capabilities!(content_blocks)
 
       request_id = @json_rpc.next_id
       @response_handler.register_prompt(request_id, session_id)
@@ -102,7 +106,7 @@ module AcpClient
       message = @json_rpc.session_prompt_message(
         request_id: request_id,
         session_id: session_id,
-        prompt_text: text
+        prompt: content_blocks
       )
       @process_manager.send_message(message)
 
@@ -127,7 +131,41 @@ module AcpClient
       @process_manager&.shutdown
     end
 
+    def prompt_capabilities
+      agent_capabilities.dig("promptCapabilities") || {}
+    end
+
     private
+
+    def normalize_prompt(prompt)
+      case prompt
+      when String
+        [{type: "text", text: prompt}]
+      when Array
+        prompt.map { |block| block.is_a?(Hash) ? block : {type: "text", text: block.to_s} }
+      else
+        [{type: "text", text: prompt.to_s}]
+      end
+    end
+
+    def validate_prompt_capabilities!(content_blocks)
+      caps = prompt_capabilities
+      return if caps.empty?
+
+      content_blocks.each do |block|
+        type = block[:type] || block["type"]
+        case type.to_s
+        when "text", "resource_link"
+          # baseline, always supported
+        when "image"
+          raise SessionError, "Agent does not support image in prompt (promptCapabilities.image)" unless caps["image"]
+        when "audio"
+          raise SessionError, "Agent does not support audio in prompt (promptCapabilities.audio)" unless caps["audio"]
+        when "resource"
+          raise SessionError, "Agent does not support embedded resource in prompt (promptCapabilities.embeddedContext)" unless caps["embeddedContext"]
+        end
+      end
+    end
 
     def run_interactive_loop
       loop do

--- a/lib/acp_client/json_rpc.rb
+++ b/lib/acp_client/json_rpc.rb
@@ -51,16 +51,15 @@ module AcpClient
       }
     end
 
-    def session_prompt_message(request_id:, session_id:, prompt_text:)
+    # @param prompt [Array<Hash>] ContentBlock array (e.g. [{type: "text", text: "..."}], [{type: "image", mimeType: "image/png", data: "..."}])
+    def session_prompt_message(request_id:, session_id:, prompt:)
       {
         jsonrpc: JSON_RPC_VERSION,
         id: request_id,
         method: "session/prompt",
         params: {
           sessionId: session_id,
-          prompt: [
-            {type: "text", text: prompt_text}
-          ]
+          prompt: prompt
         }
       }
     end

--- a/test/test_json_rpc.rb
+++ b/test/test_json_rpc.rb
@@ -34,7 +34,7 @@ class TestJsonRpc < Minitest::Test
     msg = @rpc.session_prompt_message(
       request_id: 42,
       session_id: "sess_abc",
-      prompt_text: "Hello"
+      prompt: [{type: "text", text: "Hello"}]
     )
 
     assert_equal "2.0", msg[:jsonrpc]
@@ -42,6 +42,22 @@ class TestJsonRpc < Minitest::Test
     assert_equal "session/prompt", msg[:method]
     assert_equal "sess_abc", msg[:params][:sessionId]
     assert_equal [{type: "text", text: "Hello"}], msg[:params][:prompt]
+  end
+
+  def test_session_prompt_message_extended_content
+    prompt = [
+      {type: "text", text: "Analyze this image"},
+      {type: "image", mimeType: "image/png", data: "iVBORw0KGgo="},
+      {type: "resource", resource: {uri: "file:///tmp/code.py", mimeType: "text/x-python", text: "print(1)"}}
+    ]
+    msg = @rpc.session_prompt_message(request_id: 43, session_id: "sess_xyz", prompt: prompt)
+
+    assert_equal "session/prompt", msg[:method]
+    assert_equal 3, msg[:params][:prompt].size
+    assert_equal "image", msg[:params][:prompt][1][:type]
+    assert_equal "image/png", msg[:params][:prompt][1][:mimeType]
+    assert_equal "resource", msg[:params][:prompt][2][:type]
+    assert_equal "file:///tmp/code.py", msg[:params][:prompt][2][:resource][:uri]
   end
 
   def test_session_cancel_message

--- a/test/test_prompt_extended.rb
+++ b/test/test_prompt_extended.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestPromptExtended < Minitest::Test
+  def setup
+    @pm = MockProcessManager.new
+    @pm.start
+    @rpc = AcpClient::JsonRpc.new
+    @handler = AcpClient::ResponseHandler.new(process_manager: @pm, json_rpc: @rpc)
+  end
+
+  def teardown
+    @pm.close
+  end
+
+  def test_session_prompt_with_extended_content_sent_correctly
+    @handler.start_threads
+    init_and_session_flow(@pm, prompt_capabilities: {"image" => true, "embeddedContext" => true})
+    @handler.wait_for_ready
+
+    prompt = [
+      {type: "text", text: "Analyze this"},
+      {type: "image", mimeType: "image/png", data: "iVBORw0KGgo="},
+      {type: "resource", resource: {uri: "file:///tmp/x.py", mimeType: "text/x-python", text: "print(1)"}}
+    ]
+
+    request_id = @rpc.next_id
+    @handler.register_prompt(request_id, "sess_test123")
+    msg = @rpc.session_prompt_message(request_id: request_id, session_id: "sess_test123", prompt: prompt)
+    @pm.send_message(msg)
+
+    prompt_sent = @pm.messages_sent.find { |m| m[:method] == "session/prompt" }
+    assert prompt_sent, "Expected session/prompt message"
+    assert_equal 3, prompt_sent[:params][:prompt].size
+    assert_equal "image", prompt_sent[:params][:prompt][1][:type]
+    assert_equal "resource", prompt_sent[:params][:prompt][2][:type]
+  end
+
+  private
+
+  def init_and_session_flow(pm, prompt_capabilities: {})
+    pm.inject_stdout_line({
+      "jsonrpc" => "2.0",
+      "id" => 0,
+      "result" => {
+        "protocolVersion" => 1,
+        "agentCapabilities" => {"promptCapabilities" => prompt_capabilities}
+      }
+    }.to_json)
+    pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 1, "result" => {"sessionId" => "sess_test123"}}.to_json)
+  end
+end


### PR DESCRIPTION
## 概要
Issue #10 / Milestone 7: プロンプトの拡張コンテンツを実装しました。

## 変更内容

### session/prompt の拡張
- `prompt` を ContentBlock 配列で受け取り（text, image, audio, resource, resource_link）
- `send_prompt` が String または ContentBlock 配列をサポート

### Content タイプ
- **text** / **resource_link**: 常にサポート（baseline）
- **image**: `promptCapabilities.image` が必要
- **audio**: `promptCapabilities.audio` が必要
- **resource** (embedded): `promptCapabilities.embeddedContext` が必要

### PromptCapabilities 検証
- 送信前に Agent の capability をチェック
- 未サポートの content タイプで `SessionError` を raise

### その他
- `Client#prompt_capabilities`: Agent の prompt capabilities を取得
- `Client.new(process_manager:)`: テスト用に process_manager を注入可能

## 使用例
```ruby
# テキストのみ
client.send_prompt("Hello")

# 複数 ContentBlock
client.send_prompt([
  {type: "text", text: "Analyze this"},
  {type: "image", mimeType: "image/png", data: "base64..."},
  {type: "resource", resource: {uri: "file:///x.py", mimeType: "text/x-python", text: "code"}}
])
```

## テスト
- `test/test_prompt_extended.rb` を追加
- `test/test_json_rpc.rb` に extended content のテストを追加

Closes #10

Made with [Cursor](https://cursor.com)