### PR TITLE
feat: Milestone 8 - 設定の柔軟化 (Issue #11)

### DIFF
--- a/lib/acp_client/client.rb
+++ b/lib/acp_client/client.rb
@@ -4,9 +4,19 @@ module AcpClient
   class Client
     attr_reader :json_rpc, :process_manager, :response_handler
 
-    def initialize(fs_read_text_file: nil, fs_write_text_file: nil, process_manager: nil)
+    def initialize(
+      fs_read_text_file: nil,
+      fs_write_text_file: nil,
+      process_manager: nil,
+      client_capabilities: nil,
+      client_info: nil,
+      agent_command: nil,
+      agent_env: nil
+    )
       @json_rpc = JsonRpc.new
-      @process_manager = process_manager || ProcessManager.new
+      @process_manager = process_manager || ProcessManager.new(command: agent_command, env: agent_env)
+      @client_capabilities = client_capabilities
+      @client_info = client_info
       @response_handler = nil
       @fs_read_text_file = fs_read_text_file
       @fs_write_text_file = fs_write_text_file
@@ -46,7 +56,10 @@ module AcpClient
 
       @response_handler.start_threads
 
-      message = @json_rpc.initialize_message
+      message = @json_rpc.initialize_message(
+        client_capabilities: @client_capabilities,
+        client_info: @client_info
+      )
       @process_manager.send_message(message)
 
       @response_handler.wait_for_ready

--- a/lib/acp_client/json_rpc.rb
+++ b/lib/acp_client/json_rpc.rb
@@ -19,22 +19,30 @@ module AcpClient
       id
     end
 
-    def initialize_message
+    DEFAULT_CLIENT_CAPABILITIES = {
+      fs: {readTextFile: true, writeTextFile: true},
+      terminal: true
+    }.freeze
+
+    DEFAULT_CLIENT_INFO = {
+      name: "ruby-acp-client",
+      title: "Ruby ACP Client",
+      version: AcpClient::VERSION
+    }.freeze
+
+    # @param client_capabilities [Hash, nil] Override client capabilities (deep merged with defaults)
+    # @param client_info [Hash, nil] Override clientInfo (merged with defaults)
+    def initialize_message(client_capabilities: nil, client_info: nil)
+      caps = client_capabilities ? deep_merge(DEFAULT_CLIENT_CAPABILITIES, deep_normalize_keys(client_capabilities)) : DEFAULT_CLIENT_CAPABILITIES
+      info = client_info ? DEFAULT_CLIENT_INFO.merge(normalize_keys(client_info)) : DEFAULT_CLIENT_INFO
       {
         jsonrpc: JSON_RPC_VERSION,
         id: INITIALIZE_ID,
         method: "initialize",
         params: {
           protocolVersion: 1,
-          clientCapabilities: {
-            fs: {readTextFile: true, writeTextFile: true},
-            terminal: true
-          },
-          clientInfo: {
-            name: "ruby-acp-client",
-            title: "Ruby ACP Client",
-            version: AcpClient::VERSION
-          }
+          clientCapabilities: caps,
+          clientInfo: info
         }
       }
     end
@@ -106,6 +114,27 @@ module AcpClient
         method: method,
         params: params
       }
+    end
+
+    private
+
+    def normalize_keys(hash)
+      hash.transform_keys { |k| k.is_a?(Symbol) ? k : k.to_s.to_sym }
+    end
+
+    def deep_normalize_keys(obj)
+      case obj
+      when Hash
+        obj.transform_keys { |k| k.is_a?(Symbol) ? k : k.to_s.to_sym }.transform_values { |v| deep_normalize_keys(v) }
+      else
+        obj
+      end
+    end
+
+    def deep_merge(base, override)
+      base.merge(override) do |_key, old_val, new_val|
+        (old_val.is_a?(Hash) && new_val.is_a?(Hash)) ? deep_merge(old_val, new_val) : new_val
+      end
     end
   end
 end

--- a/lib/acp_client/process_manager.rb
+++ b/lib/acp_client/process_manager.rb
@@ -9,7 +9,11 @@ module AcpClient
 
     attr_reader :stdin, :stdout, :stderr, :wait_thr
 
-    def initialize
+    # @param command [String, nil] Agent command (default: ACP_COMMAND)
+    # @param env [Hash, nil] Environment variables to merge with ENV (e.g. {"VAR" => "value"})
+    def initialize(command: nil, env: nil)
+      @command = command || ACP_COMMAND
+      @env = env
       @stdin = nil
       @stdout = nil
       @stderr = nil
@@ -20,7 +24,12 @@ module AcpClient
     def start
       raise ConnectionError, "Process already running" if @running
 
-      @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(ACP_COMMAND)
+      if @env && !@env.empty?
+        merged_env = ENV.to_h.merge(@env.transform_keys(&:to_s))
+        @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(merged_env, @command)
+      else
+        @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(@command)
+      end
       @running = true
     end
 

--- a/test/test_config_flexibility.rb
+++ b/test/test_config_flexibility.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestConfigFlexibility < Minitest::Test
+  def setup
+    @pm = MockProcessManager.new
+    @pm.start
+  end
+
+  def teardown
+    @pm.close
+  end
+
+  def test_process_manager_custom_command
+    pm = AcpClient::ProcessManager.new(command: "sleep 2")
+    pm.start
+    assert pm.running?
+    pm.shutdown
+  end
+
+  def test_process_manager_custom_env
+    pm = AcpClient::ProcessManager.new(command: "sleep 2", env: {"ACP_TEST_VAR" => "test_value"})
+    pm.start
+    assert pm.running?
+    pm.shutdown
+  end
+
+  def test_client_sends_custom_client_capabilities
+    client = AcpClient::Client.new(
+      process_manager: @pm,
+      client_capabilities: {fs: {readTextFile: false}, terminal: false}
+    )
+    Thread.new do
+      sleep 0.1
+      @pm.inject_stdout_line({
+        "jsonrpc" => "2.0",
+        "id" => 0,
+        "result" => {"protocolVersion" => 1, "agentCapabilities" => {}}
+      }.to_json)
+      @pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 1, "result" => {"sessionId" => "sess_abc"}}.to_json)
+    end
+    client.connect
+
+    init_msg = @pm.messages_sent.find { |m| m[:method] == "initialize" }
+    assert init_msg, "Expected initialize message"
+    assert_equal false, init_msg[:params][:clientCapabilities][:fs][:readTextFile]
+    assert_equal false, init_msg[:params][:clientCapabilities][:terminal]
+  end
+
+  def test_client_sends_custom_client_info
+    client = AcpClient::Client.new(
+      process_manager: @pm,
+      client_info: {name: "custom-client", title: "Custom", version: "9.9.9"}
+    )
+    Thread.new do
+      sleep 0.1
+      @pm.inject_stdout_line({
+        "jsonrpc" => "2.0",
+        "id" => 0,
+        "result" => {"protocolVersion" => 1, "agentCapabilities" => {}}
+      }.to_json)
+      @pm.inject_stdout_line({"jsonrpc" => "2.0", "id" => 1, "result" => {"sessionId" => "sess_xyz"}}.to_json)
+    end
+    client.connect
+
+    init_msg = @pm.messages_sent.find { |m| m[:method] == "initialize" }
+    assert init_msg, "Expected initialize message"
+    assert_equal "custom-client", init_msg[:params][:clientInfo][:name]
+    assert_equal "Custom", init_msg[:params][:clientInfo][:title]
+    assert_equal "9.9.9", init_msg[:params][:clientInfo][:version]
+  end
+end

--- a/test/test_json_rpc.rb
+++ b/test/test_json_rpc.rb
@@ -20,6 +20,24 @@ class TestJsonRpc < Minitest::Test
     assert_equal "ruby-acp-client", msg[:params][:clientInfo][:name]
   end
 
+  def test_initialize_message_custom_client_capabilities
+    msg = @rpc.initialize_message(
+      client_capabilities: {fs: {readTextFile: false}, terminal: false}
+    )
+    assert_equal false, msg[:params][:clientCapabilities][:fs][:readTextFile]
+    assert_equal true, msg[:params][:clientCapabilities][:fs][:writeTextFile]
+    assert_equal false, msg[:params][:clientCapabilities][:terminal]
+  end
+
+  def test_initialize_message_custom_client_info
+    msg = @rpc.initialize_message(
+      client_info: {name: "my-app", title: "My App", version: "2.0.0"}
+    )
+    assert_equal "my-app", msg[:params][:clientInfo][:name]
+    assert_equal "My App", msg[:params][:clientInfo][:title]
+    assert_equal "2.0.0", msg[:params][:clientInfo][:version]
+  end
+
   def test_session_new_message
     msg = @rpc.session_new_message(cwd: "/tmp", mcp_servers: [])
 


### PR DESCRIPTION
## 概要
Issue #11 / Milestone 8: 設定の柔軟化を実装しました。

## 変更内容

### JsonRpc#initialize_message
- `client_capabilities:` - clientCapabilities をデフォルトと deep merge
- `client_info:` - clientInfo をデフォルトと merge

### ProcessManager
- `command:` - 起動コマンドの指定（デフォルト: npx -y @zed-industries/claude-code-acp）
- `env:` - 環境変数の指定（ENV と merge して子プロセスに渡す）

### Client
- `client_capabilities:` - initialize 時の clientCapabilities をカスタマイズ
- `client_info:` - initialize 時の clientInfo をカスタマイズ
- `agent_command:` - ProcessManager の起動コマンド
- `agent_env:` - ProcessManager の環境変数

## 使用例
```ruby
# カスタム client capabilities（fs の readTextFile を無効化）
client = AcpClient::Client.new(
  client_capabilities: {fs: {readTextFile: false}, terminal: false}
)

# カスタム client info
client = AcpClient::Client.new(
  client_info: {name: "my-app", title: "My App", version: "1.0.0"}
)

# カスタム Agent コマンド・環境変数
client = AcpClient::Client.new(
  agent_command: "/path/to/custom-acp",
  agent_env: {"DEBUG" => "1"}
)
```

## テスト
- `test/test_config_flexibility.rb` を追加
- `test/test_json_rpc.rb` に initialize_message のカスタムテストを追加

Closes #11

Made with [Cursor](https://cursor.com)